### PR TITLE
Update the gems to fix the heroku instance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    daemons (1.1.9)
+    daemons (1.2.4)
     erubis (2.7.0)
-    eventmachine (1.0.3)
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    eventmachine (1.2.5)
+    mustermann (1.0.0)
+    rack (2.0.3)
+    rack-protection (2.0.0)
       rack
-    rack-ssl (1.3.3)
+    rack-ssl (1.4.1)
       rack
-    sinatra (1.4.2)
-      rack (~> 1.5, >= 1.5.2)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    thin (1.5.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
-    tilt (1.3.6)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    tilt (2.0.8)
 
 PLATFORMS
   ruby
@@ -27,3 +29,6 @@ DEPENDENCIES
   rack-ssl
   sinatra
   thin
+
+BUNDLED WITH
+   1.14.5


### PR DESCRIPTION
The heroku site is throwing an application error for everyone who visits. mkpassword is a great little utility and it would be nice to have it back up.

This PR was created by running `bundler update` to bring everything up to date. I haven't made any changes other than that.

Depending on when the heroku app was created, it may require [updating the stack](https://devcenter.heroku.com/articles/stack#migrating-to-a-new-stack).

This is running nicely on Heroku-16 via [https://mkpasswd2.herokuapp.com/](https://mkpasswd2.herokuapp.com/)

